### PR TITLE
Use `character` instead of `char` as a variable name

### DIFF
--- a/lib/luaparse.js
+++ b/lib/luaparse.js
@@ -473,14 +473,14 @@
       , range: [index, index]
     };
 
-    var char = input.charCodeAt(index)
+    var character = input.charCodeAt(index)
       , next = input.charCodeAt(index + 1);
 
     // Memorize the range index where the token begins.
     tokenStart = index;
-    if (isIdentifierStart(char)) return scanIdentifierOrKeyword();
+    if (isIdentifierStart(character)) return scanIdentifierOrKeyword();
 
-    switch (char) {
+    switch (character) {
       case 39: case 34: // '"
         return scanStringLiteral();
 
@@ -538,10 +538,10 @@
 
   function skipWhiteSpace() {
     while (index < length) {
-      var char = input.charCodeAt(index);
-      if (isWhiteSpace(char)) {
+      var character = input.charCodeAt(index);
+      if (isWhiteSpace(character)) {
         index++;
-      } else if (isLineTerminator(char)) {
+      } else if (isLineTerminator(character)) {
         line++;
         lineStart = ++index;
       } else {
@@ -617,20 +617,20 @@
     var delimiter = input.charCodeAt(index++)
       , stringStart = index
       , string = ''
-      , char;
+      , character;
 
     while (index < length) {
-      char = input.charCodeAt(index++);
-      if (delimiter === char) break;
-      if (92 === char) { // \
+      character = input.charCodeAt(index++);
+      if (delimiter === character) break;
+      if (92 === character) { // \
         string += input.slice(stringStart, index - 1) + readEscapeSequence();
         stringStart = index;
       }
       // EOF or `\n` terminates a string literal. If we haven't found the
       // ending delimiter by now, raise an exception.
-      else if (index >= length || isLineTerminator(char)) {
+      else if (index >= length || isLineTerminator(character)) {
         string += input.slice(stringStart, index - 1);
-        raise({}, errors.unfinishedString, string + String.fromCharCode(char));
+        raise({}, errors.unfinishedString, string + String.fromCharCode(character));
       }
     }
     string += input.slice(stringStart, index - 1);
@@ -669,10 +669,10 @@
   // If a hexadecimal number is encountered, it will be converted.
 
   function scanNumericLiteral() {
-    var char = input.charAt(index)
+    var character = input.charAt(index)
       , next = input.charAt(index + 1);
 
-    var value = ('0' === char && ~'xX'.indexOf(next || null)) ?
+    var value = ('0' === character && ~'xX'.indexOf(next || null)) ?
       readHexLiteral() : readDecLiteral();
 
     return {
@@ -821,15 +821,15 @@
     tokenStart = index;
     index += 2; // --
 
-    var char = input.charAt(index)
+    var character = input.charAt(index)
       , content = ''
       , isLong = false
       , commentStart = index;
 
-    if ('[' === char) {
+    if ('[' === character) {
       content = readLongString();
       // This wasn't a multiline comment after all.
-      if (false === content) content = char;
+      if (false === content) content = character;
       else {
         isLong = true;
         index += 2; // Trailing --
@@ -860,7 +860,7 @@
     var level = 0
       , content = ''
       , terminator = false
-      , char, stringStart;
+      , character, stringStart;
 
     index++; // [
 
@@ -879,11 +879,11 @@
 
     stringStart = index;
     while (index < length) {
-      char = input.charAt(index++);
+      character = input.charAt(index++);
 
       // We have to keep track of newlines as `skipWhiteSpace()` does not get
       // to scan this part.
-      if (isLineTerminator(char.charCodeAt(0))) {
+      if (isLineTerminator(character.charCodeAt(0))) {
         line++;
         lineStart = index;
       }
@@ -891,7 +891,7 @@
       // Once the delimiter is found, iterate through the depth count and see
       // if it matches.
 
-      if (']' === char) {
+      if (']' === character) {
         terminator = true;
         for (var i = 0; i < level; i++) {
           if ('=' !== input.charAt(index + i)) terminator = false;
@@ -902,7 +902,7 @@
       // We reached the end of the multiline string. Get out now.
       if (terminator) break;
 
-      if ('\\' === char) {
+      if ('\\' === character) {
         content += input.slice(stringStart, index - 1) + readEscapeSequence();
         stringStart = index;
       }
@@ -955,31 +955,31 @@
 
   // ### Validation functions
 
-  function isWhiteSpace(char) {
-    return 9 === char || 32 === char || 0xB === char || 0xC === char;
+  function isWhiteSpace(character) {
+    return 9 === character || 32 === character || 0xB === character || 0xC === character;
   }
 
-  function isLineTerminator(char) {
-    return 10 === char || 13 === char;
+  function isLineTerminator(character) {
+    return 10 === character || 13 === character;
   }
 
-  function isDecDigit(char) {
-    return char >= 48 && char <= 57;
+  function isDecDigit(character) {
+    return character >= 48 && character <= 57;
   }
 
-  function isHexDigit(char) {
-    return (char >= 48 && char <= 57) || (char >= 97 && char <= 102) || (char >= 65 && char <= 70);
+  function isHexDigit(character) {
+    return (character >= 48 && character <= 57) || (character >= 97 && character <= 102) || (character >= 65 && character <= 70);
   }
 
   // From [Lua 5.2](http://www.lua.org/manual/5.2/manual.html#8.1) onwards
   // identifiers cannot use locale-dependet letters.
 
-  function isIdentifierStart(char) {
-    return (char >= 65 && char <= 90) || (char >= 97 && char <= 122) || 95 === char;
+  function isIdentifierStart(character) {
+    return (character >= 65 && character <= 90) || (character >= 97 && character <= 122) || 95 === character;
   }
 
-  function isIdentifierPart(char) {
-    return (char >= 65 && char <= 90) || (char >= 97 && char <= 122) || 95 === char || (char >= 48 && char <= 57);
+  function isIdentifierPart(character) {
+    return (character >= 65 && character <= 90) || (character >= 97 && character <= 122) || 95 === character || (character >= 48 && character <= 57);
   }
 
   // [3.1 Lexical Conventions](http://www.lua.org/manual/5.2/manual.html#3.1)
@@ -1572,23 +1572,23 @@
   // the expensive CompareICStub which took ~8% of the parse time.
 
   function binaryPrecedence(operator) {
-    var char = operator.charCodeAt(0)
+    var character = operator.charCodeAt(0)
       , length = operator.length;
 
     if (1 === length) {
-      switch (char) {
+      switch (character) {
         case 94: return 10; // ^
         case 42: case 47: case 37: return 7; // * / %
         case 43: case 45: return 6; // + -
         case 60: case 62: return 3; // < >
       }
     } else if (2 === length) {
-      switch (char) {
+      switch (character) {
         case 46: return 5; // ..
         case 60: case 62: case 61: case 126: return 3; // <= >= == ~=
         case 111: return 1; // or
       }
-    } else if (97 === char && 'and' === operator) return 2;
+    } else if (97 === character && 'and' === operator) return 2;
     return 0;
   }
 


### PR DESCRIPTION
`char` used to be a reserved word in ES3 (http://mothereff.in/js-variables#char). This simple change avoids errors in older JavaScript engines such as Narwhal.
