### PR TITLE
Update old GitHub Pages URLs

### DIFF
--- a/docs/layout/head.html
+++ b/docs/layout/head.html
@@ -3,8 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>Luaparse</title>
-    <link href="http://twitter.github.com/bootstrap/assets/css/bootstrap.css" rel="stylesheet">
-    <link href="http://twitter.github.com/bootstrap/assets/css/bootstrap-responsive.css" rel="stylesheet">
+    <link href="http://twitter.github.io/bootstrap/assets/css/bootstrap.css" rel="stylesheet">
+    <link href="http://twitter.github.io/bootstrap/assets/css/bootstrap-responsive.css" rel="stylesheet">
     <style>
       .hero-unit .nav-pills a {
         font-size: 70%;
@@ -26,7 +26,7 @@
           </div>
           <div class="span6" style="padding-top: 35px;">
             <div class="btn-group">
-              <a class="btn" href="https://github.com/oxyc/luaparse">Github</a>
+              <a class="btn" href="https://github.com/oxyc/luaparse">GitHub</a>
               <a class="btn" href="luaparse.html">Annotated source</a>
               <a class="btn" href="tests.html">Test docs</a>
             </div>

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "luaparse",
   "description": "A Lua parser in JavaScript",
   "version": "0.0.11",
-  "homepage": "http://oxyc.github.com/luaparse/",
+  "homepage": "http://oxyc.github.io/luaparse/",
   "bugs": "https://github.com/oxyc/luaparse/issues",
   "author": {
     "name": "Oskar Schöldström",

--- a/test/lib/benchmark.js
+++ b/test/lib/benchmark.js
@@ -1327,7 +1327,7 @@
           }
         }
         // continue clone if `value` doesn't have an accessor descriptor
-        // http://es5.github.com/#x8.10.1
+        // http://es5.github.io/#x8.10.1
         if (clone && clone != value &&
             !(descriptor = source && support.descriptors && getDescriptor(source, key),
               accessor = descriptor && (descriptor.get || descriptor.set))) {

--- a/test/lib/expect.js
+++ b/test/lib/expect.js
@@ -528,7 +528,7 @@
     return j <= i ? -1 : i;
   };
 
-  // https://gist.github.com/1044128/
+  // https://gist.github.com/eligrey/1044128/
   var getOuterHTML = function(element) {
     if ('outerHTML' in element) return element.outerHTML;
     var ns = "http://www.w3.org/1999/xhtml";


### PR DESCRIPTION
See https://github.com/blog/1452-new-github-pages-domain-github-io.

At the moment, http://oxyc.github.io/luaparse/ is unstyled. This PR fixes that, too.
