### PR TITLE
PrintTable improvements

### DIFF
--- a/benchmarks/lib/ParseLua.lua
+++ b/benchmarks/lib/ParseLua.lua
@@ -30,22 +30,25 @@ function PrintTable(tb, atIndent)
   local baseIndent = string.rep('    ', atIndent+1)
   local out = "{"..(useNewlines and '\n' or '')
   for k, v in pairs(tb) do
-    if type(v) ~= 'function' then
+    tmpType = type(v)
+    if tmpType ~= 'function' then
       out = out..(useNewlines and baseIndent or '')
-      if type(k) == 'number' then
+      if tmpType == 'number' then
         --nothing to do
-      elseif type(k) == 'string' and k:match("^[A-Za-z_][A-Za-z0-9_]*$") then 
-        out = out..k.." = "
-      elseif type(k) == 'string' then
-        out = out.."[\""..k.."\"] = "
+      elseif tmpType == 'string' then
+        if k:match("^[A-Za-z_][A-Za-z0-9_]*$") then 
+            out = out..k.." = "
+        else
+            out = out.."[\""..k.."\"] = "
+        end
       else
         out = out.."["..tostring(k).."] = "
       end
-      if type(v) == 'string' then
+      if tmpType == 'string' then
         out = out.."\""..v.."\""
-      elseif type(v) == 'number' then
+      elseif tmpType == 'number' then
         out = out..v
-      elseif type(v) == 'table' then
+      elseif tmpType == 'table' then
         out = out..PrintTable(v, atIndent+(useNewlines and 1 or 0))
       else
         out = out..tostring(v)

--- a/benchmarks/lib/ParseLua.lua
+++ b/benchmarks/lib/ParseLua.lua
@@ -29,6 +29,7 @@ function PrintTable(tb, atIndent)
   local useNewlines = (CountTable(tb) > 1)
   local baseIndent = string.rep('    ', atIndent+1)
   local out = "{"..(useNewlines and '\n' or '')
+  local tmpType
   for k, v in pairs(tb) do
     tmpType = type(v)
     if tmpType ~= 'function' then

--- a/benchmarks/lib/ParseLua.lua
+++ b/benchmarks/lib/ParseLua.lua
@@ -39,13 +39,13 @@ function PrintTable(tb, atIndent)
         if k:match("^[A-Za-z_][A-Za-z0-9_]*$") then 
             out = out..k.." = "
         else
-            out = out.."[\""..k.."\"] = "
+            out = out.."["..string.format("%q", k).."] = "
         end
       else
         out = out.."["..tostring(k).."] = "
       end
       if tmpType == 'string' then
-        out = out.."\""..v.."\""
+        out = out..string.format("%q", v)
       elseif tmpType == 'number' then
         out = out..v
       elseif tmpType == 'table' then


### PR DESCRIPTION
It's also possible to use `next, tb` instead of `pairs(tb)` if you're not interested in `getmetatable(tb).__pairs`'s behavior