### PR TITLE
Allow preserving parenthesis.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ The available options are:
   appearing in parser input and raw bytes in source code, and how Lua escape
   sequences in JavaScript strings should be interpreted. See the
   [Encoding modes](#encoding-modes) section below for more information.
+- `preserveParens: false` If this option is true, parenthesized expressions are represented by (non-standard) ParenthesizedExpression nodes that have a single expression property containing the expression inside parentheses.
 
 The default options are also exposed through `luaparse.defaultOptions` where
 they can be overriden globally.

--- a/luaparse.js
+++ b/luaparse.js
@@ -88,6 +88,9 @@
     , luaVersion: '5.1'
     // Encoding mode: how to interpret code units higher than U+007F in input
     , encodingMode: 'none'
+    // If this option is true, parenthesized expressions are represented by (non-standard) ParenthesizedExpression nodes
+    // that have a single expression property containing the expression inside parentheses.
+    , preserveParens: false
   };
 
   function encodeUTF8(codepoint, highMask) {
@@ -230,6 +233,13 @@
       return {
           type: 'LabelStatement'
         , label: label
+      };
+    }
+    
+    , parenthesizedExpression: function(expression) {
+      return {
+          type: 'ParenthesizedExpression'
+        , expression: expression
       };
     }
 
@@ -2517,8 +2527,10 @@
       // Set the parent scope.
       if (options.scope) attachScope(base, scopeHasName(name));
     } else if (consume('(')) {
+      if (options.preserveParens) pushLocation(mark);
       base = parseExpectedExpression(flowContext);
       expect(')');
+      if (options.preserveParens) base = finishNode(ast.parenthesizedExpression(base));
     } else {
       return null;
     }


### PR DESCRIPTION
This is very useful for when converting the tree back to source code to know where parenthesis have been used by the user.

This is inspired by [acornjs](https://github.com/acornjs/acorn/tree/master/acorn) and is exactly how they did it.