### PR TITLE
Detect missing first argument in calls and return statements

### DIFF
--- a/luaparse.js
+++ b/luaparse.js
@@ -1918,10 +1918,12 @@
 
     if ('end' !== token.value) {
       var expression = parseExpression(flowContext);
-      if (null != expression) expressions.push(expression);
-      while (consume(',')) {
-        expression = parseExpectedExpression(flowContext);
+      if (null != expression) {
         expressions.push(expression);
+        while (consume(',')) {
+          expression = parseExpectedExpression(flowContext);
+          expressions.push(expression);
+        }
       }
       consume(';'); // grammar tells us ; is optional here.
     }
@@ -2549,10 +2551,12 @@
           // List of expressions
           var expressions = [];
           var expression = parseExpression(flowContext);
-          if (null != expression) expressions.push(expression);
-          while (consume(',')) {
-            expression = parseExpectedExpression(flowContext);
+          if (null != expression) {
             expressions.push(expression);
+            while (consume(',')) {
+              expression = parseExpectedExpression(flowContext);
+              expressions.push(expression);
+            }
           }
 
           expect(')');

--- a/test/scaffolding/functioncalls
+++ b/test/scaffolding/functioncalls
@@ -1,6 +1,7 @@
 a(                                      -- FAIL
 a()
 a(1)
+a(,1)                                   -- FAIL
 a(1,)                                   -- FAIL
 a(1,2,3)
 1()                                     -- FAIL

--- a/test/scaffolding/return
+++ b/test/scaffolding/return
@@ -2,6 +2,7 @@ return return                           -- FAIL
 return 1
 return local                            -- FAIL
 return "foo"
+return ,1                               -- FAIL
 return 1,                               -- FAIL
 return 1,2,3
 return a,b,c,d

--- a/test/spec/functioncalls.js
+++ b/test/spec/functioncalls.js
@@ -238,6 +238,10 @@
       }
     },
     {
+      "source": "a(,1)",
+      "result": "[1:2] ')' expected near ','"
+    },
+    {
       "source": "a(1,)",
       "result": "[1:4] <expression> expected near ')'"
     },

--- a/test/spec/return.js
+++ b/test/spec/return.js
@@ -150,6 +150,10 @@
       }
     },
     {
+      "source": "return ,1",
+      "result": "[1:7] unexpected symbol ',' near '1'"
+    },
+    {
       "source": "return 1,",
       "result": "[1:9] <expression> expected near '<eof>'"
     },


### PR DESCRIPTION
Reported by: Omar <omarkmu@gmail.com>

Fixes #122.